### PR TITLE
Fix darkMode config

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss"
 
 const config: Config = {
-  darkMode: ["class"],
+  darkMode: "class",
   content: [
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",


### PR DESCRIPTION
## Summary
- adjust Tailwind config `darkMode` to a supported type

## Testing
- `pnpm install` *(fails: Forbidden 403)*
- `pnpm run build` *(fails: node modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c72b02cac8323b6b831fe57438ae3